### PR TITLE
Rename column header from 'parish' to 'county'

### DIFF
--- a/2000/20000314__la__primary.csv
+++ b/2000/20000314__la__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,President,,D,Bill Bradley,395
 Acadia,President,,D,"""Randy"" Crow",47
 Acadia,President,,D,"""Al"" Gore",1050

--- a/2000/20000314__la__primary__precinct.csv
+++ b/2000/20000314__la__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Acadia,1- 1,President,Democratic Party,D,Bill Bradley,14
 Acadia,1- 1,President,Democratic Party,D,"""Randy"" Crow",1
 Acadia,1- 1,President,Democratic Party,D,"""Al"" Gore",25

--- a/2000/20001007__la__special__primary.csv
+++ b/2000/20001007__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Bienville,State House,11,O,Huey Dean,47
 Bienville,State House,11,D,"Richard ""Rick"" Gallot, Jr.",356
 Bienville,State House,11,D,Ellen D. Smiley,52

--- a/2000/20001007__la__special__primary__precinct.csv
+++ b/2000/20001007__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Bienville,2- 1,State House,11,O,Huey Dean,14
 Bienville,2- 1,State House,11,D,"Richard ""Rick"" Gallot, Jr.",85
 Bienville,2- 1,State House,11,D,Ellen D. Smiley,13

--- a/2000/20001107__la__general.csv
+++ b/2000/20001107__la__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,President,,D,Gore & Lieberman,8892
 Acadia,President,,R,Buchanan & Foster,255
 Acadia,President,,R,Bush & Cheney,13814

--- a/2000/20001107__la__general__precinct.csv
+++ b/2000/20001107__la__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Acadia,1- 1,President,,D,Gore & Lieberman,186
 Acadia,1- 1,President,,R,Buchanan & Foster,10
 Acadia,1- 1,President,,R,Bush & Cheney,414

--- a/2000/20001107__la__primary.csv
+++ b/2000/20001107__la__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Jefferson,U.S. House,1,D,Michael A. Armato,13415
 Jefferson,U.S. House,1,D,Cary J. Deaton,3878
 Jefferson,U.S. House,1,O,Martin A. Rosenthal,1255

--- a/2000/20001107__la__primary__precinct.csv
+++ b/2000/20001107__la__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Ascension,00 1,U.S. House,6,R,Richard H. Baker,889
 Ascension,00 1,U.S. House,6,D,Kathy J. Rogillio,227
 Ascension,00 1,U.S. House,6,O,Michael S. Wolf,37

--- a/2000/20001107__la__special__primary.csv
+++ b/2000/20001107__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 East Baton Rouge,State House,62,D,Myron Hall,1282
 East Baton Rouge,State House,62,R,"Thomas H. ""Tom"" McVea",2423
 East Feliciana,State House,62,D,Myron Hall,2699

--- a/2000/20001107__la__special__primary__precinct.csv
+++ b/2000/20001107__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 East Baton Rouge,2- 18A,State House,62,D,Myron Hall,258
 East Baton Rouge,2- 18A,State House,62,R,"Thomas H. ""Tom"" McVea",625
 East Baton Rouge,2- 18B,State House,62,D,Myron Hall,264

--- a/2000/20001209__la__special__general.csv
+++ b/2000/20001209__la__special__general.csv
@@ -1,3 +1,3 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 St. Bernard,State House,104,R,Nita Rusich Hutter,4055
 St. Bernard,State House,104,D,Lance V. Licciardi,3966

--- a/2000/20001209__la__special__general__precinct.csv
+++ b/2000/20001209__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 St. Bernard,00 17,State House,104,R,Nita Rusich Hutter,220
 St. Bernard,00 17,State House,104,D,Lance V. Licciardi,151
 St. Bernard,00 21,State House,104,R,Nita Rusich Hutter,137

--- a/2001/20010210__la__special__primary.csv
+++ b/2001/20010210__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Lafourche,State Senate,20,R,Chris Bollinger,4155
 Lafourche,State Senate,20,D,Mark T. Duplantis,143
 Lafourche,State Senate,20,D,"Reggie P. Dupre, Jr.",1008

--- a/2001/20010210__la__special__primary__precinct.csv
+++ b/2001/20010210__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Lafourche,10- 1,State Senate,20,R,Chris Bollinger,119
 Lafourche,10- 1,State Senate,20,D,Mark T. Duplantis,6
 Lafourche,10- 1,State Senate,20,D,"Reggie P. Dupre, Jr.",28

--- a/2001/20010217__la__special__primary.csv
+++ b/2001/20010217__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Jefferson,State House,86,R,"""Hank"" Berchak",377
 Jefferson,State House,86,R,"Robert B. ""Robby"" Evans III",1036
 Jefferson,State House,86,R,"""Ed"" Markle",530

--- a/2001/20010217__la__special__primary__precinct.csv
+++ b/2001/20010217__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Orleans,9- 39A,State House,100,D,Joe Aidoo,10
 Orleans,9- 39A,State House,100,D,Cynthia Gullette Banks,13
 Orleans,9- 39A,State House,100,D,Madalyn J. Cochrane,0

--- a/2001/20010310__la__special__general.csv
+++ b/2001/20010310__la__special__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Lafourche,State Senate,20,R,Chris Bollinger,6865
 Lafourche,State Senate,20,D,"Reggie P. Dupre, Jr.",3710
 Terrebonne,State Senate,20,R,Chris Bollinger,2641

--- a/2001/20010310__la__special__general__precinct.csv
+++ b/2001/20010310__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Lafourche,10- 1,State Senate,20,R,Chris Bollinger,217
 Lafourche,10- 1,State Senate,20,D,"Reggie P. Dupre, Jr.",132
 Lafourche,10- 10,State Senate,20,R,Chris Bollinger,242

--- a/2001/20010317__la__special__general.csv
+++ b/2001/20010317__la__special__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Jefferson,State House,86,R,"Robert B. ""Robby"" Evans III",1549
 Jefferson,State House,86,R,"""Jim"" Tucker",872
 Orleans,State House,86,R,"Robert B. ""Robby"" Evans III",245

--- a/2001/20010317__la__special__general__precinct.csv
+++ b/2001/20010317__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Orleans,9- 39A,State House,100,D,Terrie Carrie Guerin,62
 Orleans,9- 39A,State House,100,D,Patrick Swilling,80
 Orleans,9- 39B,State House,100,D,Terrie Carrie Guerin,76

--- a/2001/20010505__la__special__primary.csv
+++ b/2001/20010505__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Lafourche,State House,53,D,Damon J. Baldone,96
 Lafourche,State House,53,D,"""Johnny"" Glover",11
 Lafourche,State House,53,R,"""Connie"" Scheer",7

--- a/2001/20010505__la__special__primary__precinct.csv
+++ b/2001/20010505__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Lafourche,11- 1,State House,53,D,Damon J. Baldone,96
 Lafourche,11- 1,State House,53,D,"""Johnny"" Glover",11
 Lafourche,11- 1,State House,53,R,"""Connie"" Scheer",7

--- a/2001/20010602__la__special__general.csv
+++ b/2001/20010602__la__special__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Lafourche,State House,53,D,Damon J. Baldone,119
 Lafourche,State House,53,D,"""Johnny"" Glover",19
 Terrebonne,State House,53,D,Damon J. Baldone,3129

--- a/2001/20010602__la__special__general__precinct.csv
+++ b/2001/20010602__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Lafourche,11- 1,State House,53,D,Damon J. Baldone,119
 Lafourche,11- 1,State House,53,D,"""Johnny"" Glover",19
 Lafourche,Early Voting,State House,53,D,Damon J. Baldone,0

--- a/2001/20010721__la__special__primary.csv
+++ b/2001/20010721__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 East Baton Rouge,State House,69,R,Gary Beard,1610
 East Baton Rouge,State House,69,R,David Boneno,1181
 East Baton Rouge,State House,69,R,Eldon Ledoux,1252

--- a/2001/20010721__la__special__primary__precinct.csv
+++ b/2001/20010721__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 East Baton Rouge,1- 103A,State House,69,R,Gary Beard,53
 East Baton Rouge,1- 103A,State House,69,R,David Boneno,50
 East Baton Rouge,1- 103A,State House,69,R,Eldon Ledoux,28

--- a/2001/20010818__la__special__general.csv
+++ b/2001/20010818__la__special__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 East Baton Rouge,State House,69,R,Gary Beard,4093
 East Baton Rouge,State House,69,R,David Boneno,2847
 Livingston,State House,69,R,Gary Beard,642

--- a/2001/20010818__la__special__general__precinct.csv
+++ b/2001/20010818__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 East Baton Rouge,1- 103A,State House,69,R,Gary Beard,148
 East Baton Rouge,1- 103A,State House,69,R,David Boneno,119
 East Baton Rouge,1- 103B,State House,69,R,Gary Beard,130

--- a/2001/20011124__la__special__primary.csv
+++ b/2001/20011124__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Jefferson,State House,88,R,"Thomas ""Tom"" Capella",1861
 Jefferson,State House,88,R,Dianna Dyer,1489
 Jefferson,State House,88,R,Scott Masson,216

--- a/2001/20011124__la__special__primary__precinct.csv
+++ b/2001/20011124__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Jefferson,00 002,State House,88,R,"Thomas ""Tom"" Capella",121
 Jefferson,00 002,State House,88,R,Dianna Dyer,70
 Jefferson,00 002,State House,88,R,Scott Masson,39

--- a/2001/20011215__la__special__primary.csv
+++ b/2001/20011215__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 East Baton Rouge,State Senate,15,D,Brenda Bennett Carter,201
 East Baton Rouge,State Senate,15,D,"John ""Tick"" Cobb",257
 East Baton Rouge,State Senate,15,D,"Melvin L. ""Kip"" Holden",6319

--- a/2001/20011215__la__special__primary__precinct.csv
+++ b/2001/20011215__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 East Baton Rouge,1- 100A,State Senate,15,D,Brenda Bennett Carter,0
 East Baton Rouge,1- 100A,State Senate,15,D,"John ""Tick"" Cobb",3
 East Baton Rouge,1- 100A,State Senate,15,D,"Melvin L. ""Kip"" Holden",18

--- a/2002/20020302__la__special__primary.csv
+++ b/2002/20020302__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 East Baton Rouge,State House,63,D,"Ulysses ""Bones"" Addison, Jr.",516
 East Baton Rouge,State House,63,D,Avon R. Honey,2244
 East Baton Rouge,State House,63,R,"Arnold ""Pop"" Johnson",127

--- a/2002/20020302__la__special__primary__precinct.csv
+++ b/2002/20020302__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 East Baton Rouge,01 084A,State House,63,D,"Ulysses ""Bones"" Addison, Jr.",6
 East Baton Rouge,01 084A,State House,63,D,Avon R. Honey,17
 East Baton Rouge,01 084A,State House,63,R,"Arnold ""Pop"" Johnson",0

--- a/2002/20020406__la__special__primary.csv
+++ b/2002/20020406__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Orleans,State House,91,D,Jalila Jefferson,1735
 Orleans,State House,91,D,Shane Landry,633
 Orleans,State House,91,D,Rosalind Magee Peychaud,1460

--- a/2002/20020406__la__special__primary__precinct.csv
+++ b/2002/20020406__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Orleans,10 08,State House,91,D,Jalila Jefferson,15
 Orleans,10 08,State House,91,D,Shane Landry,47
 Orleans,10 08,State House,91,D,Rosalind Magee Peychaud,32

--- a/2002/20020504__la__special__general.csv
+++ b/2002/20020504__la__special__general.csv
@@ -1,3 +1,3 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Orleans,State House,91,D,Jalila Jefferson,2291
 Orleans,State House,91,D,Rosalind Magee Peychaud,2401

--- a/2002/20020504__la__special__general__precinct.csv
+++ b/2002/20020504__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Orleans,10 08,State House,91,D,Jalila Jefferson,25
 Orleans,10 08,State House,91,D,Rosalind Magee Peychaud,67
 Orleans,10 09,State House,91,D,Jalila Jefferson,17

--- a/2002/20021105__la__primary.csv
+++ b/2002/20021105__la__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,U.S. Senate,,D,Raymond Brown,358
 Acadia,U.S. Senate,,R,John Cooksey,2516
 Acadia,U.S. Senate,,D,Mary Landrieu,6991

--- a/2002/20021105__la__primary__precinct.csv
+++ b/2002/20021105__la__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Acadia,01 01,U.S. Senate,,D,Raymond Brown,6
 Acadia,01 01,U.S. Senate,,R,John Cooksey,50
 Acadia,01 01,U.S. Senate,,D,Mary Landrieu,127

--- a/2002/20021207__la__general.csv
+++ b/2002/20021207__la__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,U.S. Senate,,D,Mary Landrieu,7195
 Acadia,U.S. Senate,,R,Suzanne Haik Terrell,8214
 Allen,U.S. Senate,,D,Mary Landrieu,3111

--- a/2002/20021207__la__general__precinct.csv
+++ b/2002/20021207__la__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Acadia,01 01,U.S. Senate,,D,Mary Landrieu,128
 Acadia,01 01,U.S. Senate,,R,Suzanne Haik Terrell,216
 Acadia,01 02A,U.S. Senate,,D,Mary Landrieu,107

--- a/2002/20021207__la__special__primary.csv
+++ b/2002/20021207__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Lincoln,State House,12,D,"James ""Jim"" Ball",1434
 Lincoln,State House,12,R,Ty Bromell,2016
 Lincoln,State House,12,R,Hollis Downs,2545

--- a/2002/20021207__la__special__primary__precinct.csv
+++ b/2002/20021207__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Lincoln,01 A1,State House,12,D,"James ""Jim"" Ball",140
 Lincoln,01 A1,State House,12,R,Ty Bromell,203
 Lincoln,01 A1,State House,12,R,Hollis Downs,283

--- a/2003/20030118__la__special__general.csv
+++ b/2003/20030118__la__special__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Lincoln,State House,12,R,Hollis Downs,2136
 Lincoln,State House,12,R,Chuck Earle,1389
 Morehouse,State House,12,R,Hollis Downs,18

--- a/2003/20030118__la__special__general__precinct.csv
+++ b/2003/20030118__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Avoyelles,01 01,State House,28,D,Robert Johnson,146
 Avoyelles,01 01,State House,28,D,Monica Walker,88
 Avoyelles,01 02,State House,28,D,Robert Johnson,204

--- a/2003/20030118__la__special__primary.csv
+++ b/2003/20030118__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Bienville,State Senate,36,D,Robert Adley,1051
 Bienville,State Senate,36,R,"T. E. ""Gene"" Coleman",173
 Bienville,State Senate,36,D,Jack Cook,38

--- a/2003/20030118__la__special__primary__precinct.csv
+++ b/2003/20030118__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Bienville,01 01,State Senate,36,D,Robert Adley,40
 Bienville,01 01,State Senate,36,R,"T. E. ""Gene"" Coleman",20
 Bienville,01 01,State Senate,36,D,Jack Cook,1

--- a/2003/20030215__la__special__general.csv
+++ b/2003/20030215__la__special__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Bienville,State Senate,36,D,Robert Adley,1555
 Bienville,State Senate,36,D,Jerry Lott,919
 Bossier,State Senate,36,D,Robert Adley,2479

--- a/2003/20030215__la__special__general__precinct.csv
+++ b/2003/20030215__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Bienville,01 01,State Senate,36,D,Robert Adley,50
 Bienville,01 01,State Senate,36,D,Jerry Lott,50
 Bienville,01 02,State Senate,36,D,Robert Adley,91

--- a/2003/20030215__la__special__primary.csv
+++ b/2003/20030215__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Bienville,State House,13,D,Todd Culpepper,378
 Bienville,State House,13,D,"James R. ""Jim"" Fannin",275
 Bienville,State House,13,D,Loyd I. Sowers,35

--- a/2003/20030215__la__special__primary__precinct.csv
+++ b/2003/20030215__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Bienville,01 01,State House,13,D,Todd Culpepper,40
 Bienville,01 01,State House,13,D,"James R. ""Jim"" Fannin",16
 Bienville,01 01,State House,13,D,Loyd I. Sowers,1

--- a/2003/20030315__la__special__general.csv
+++ b/2003/20030315__la__special__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Bienville,State House,13,D,Todd Culpepper,492
 Bienville,State House,13,D,"James R. ""Jim"" Fannin",523
 Jackson,State House,13,D,Todd Culpepper,1783

--- a/2003/20030315__la__special__general__precinct.csv
+++ b/2003/20030315__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Bienville,01 01,State House,13,D,Todd Culpepper,30
 Bienville,01 01,State House,13,D,"James R. ""Jim"" Fannin",35
 Bienville,01 02,State House,13,D,Todd Culpepper,48

--- a/2003/20031004__la__primary.csv
+++ b/2003/20031004__la__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Orleans,State Senate,1,R,Walter J. Boasso,76
 Orleans,State Senate,1,D,Wayne J. Landry,28
 Orleans,State Senate,1,R,Wayne Mumphrey,41

--- a/2003/20031115__la__general.csv
+++ b/2003/20031115__la__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,Governor,,D,Kathleen Babineaux Blanco,10938
 Acadia,Governor,,R,"""Bobby"" Jindal",8226
 Allen,Governor,,D,Kathleen Babineaux Blanco,4502

--- a/2003/20031115__la__general__precinct.csv
+++ b/2003/20031115__la__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Acadia,01 01,Governor,,D,Kathleen Babineaux Blanco,294
 Acadia,01 01,Governor,,R,"""Bobby"" Jindal",240
 Acadia,01 02A,Governor,,D,Kathleen Babineaux Blanco,129

--- a/2004/20040309__la__primary.csv
+++ b/2004/20040309__la__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,President,,D,Wesley K. Clark,86
 Acadia,President,,D,Howard Dean,94
 Acadia,President,,D,John Edwards,396

--- a/2004/20040309__la__primary__precinct.csv
+++ b/2004/20040309__la__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Acadia,01 01,President,Democratic Party,D,Wesley K. Clark,1
 Acadia,01 01,President,Democratic Party,D,Howard Dean,4
 Acadia,01 01,President,Democratic Party,D,John Edwards,14

--- a/2004/20040309__la__special__primary.csv
+++ b/2004/20040309__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Lafayette,State House,45,R,Denice Comeaux-Skinner,1165
 Lafayette,State House,45,R,"L.T. ""Butch"" Dupre'",708
 Lafayette,State House,45,R,"Steven G. ""Buzz"" Durio",1850

--- a/2004/20040309__la__special__primary__precinct.csv
+++ b/2004/20040309__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Lafayette,00 030A,State House,45,R,Denice Comeaux-Skinner,22
 Lafayette,00 030A,State House,45,R,"L.T. ""Butch"" Dupre'",66
 Lafayette,00 030A,State House,45,R,"Steven G. ""Buzz"" Durio",53

--- a/2004/20040417__la__special__general.csv
+++ b/2004/20040417__la__special__general.csv
@@ -1,3 +1,3 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Lafayette,State House,45,R,"Steven G. ""Buzz"" Durio",2223
 Lafayette,State House,45,O,Joel Robideaux,2751

--- a/2004/20040417__la__special__general__precinct.csv
+++ b/2004/20040417__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Lafayette,00 030A,State House,45,R,"Steven G. ""Buzz"" Durio",49
 Lafayette,00 030A,State House,45,O,Joel Robideaux,59
 Lafayette,00 030B,State House,45,R,"Steven G. ""Buzz"" Durio",2

--- a/2004/20040918__la__special__primary.csv
+++ b/2004/20040918__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 St. Landry,State House,40,D,Cynthia M. Ahart,1267
 St. Landry,State House,40,D,"""Joe"" Charles",285
 St. Landry,State House,40,D,"Donald ""Don"" Cravins, Jr.",3011

--- a/2004/20040918__la__special__primary__precinct.csv
+++ b/2004/20040918__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 St. Landry,01 01,State House,40,D,Cynthia M. Ahart,2
 St. Landry,01 01,State House,40,D,"""Joe"" Charles",14
 St. Landry,01 01,State House,40,D,"Donald ""Don"" Cravins, Jr.",52

--- a/2004/20041102__la__general.csv
+++ b/2004/20041102__la__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,President,,D,Kerry & Edwards,8937
 Acadia,President,,R,Bush & Cheney,16083
 Acadia,President,,O,Peroutka & Baldwin,27

--- a/2004/20041102__la__general__precinct.csv
+++ b/2004/20041102__la__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Acadia,01 01,President,,D,Kerry & Edwards,172
 Acadia,01 01,President,,R,Bush & Cheney,476
 Acadia,01 01,President,,O,Peroutka & Baldwin,1

--- a/2004/20041102__la__primary.csv
+++ b/2004/20041102__la__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,U.S. Senate,,O,Richard M. Fontanesi,193
 Acadia,U.S. Senate,,O,"R. A. ""Skip"" Galan",66
 Acadia,U.S. Senate,,D,"""Chris"" John",13401

--- a/2004/20041102__la__primary__precinct.csv
+++ b/2004/20041102__la__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Acadia,01 01,U.S. Senate,,O,Richard M. Fontanesi,6
 Acadia,01 01,U.S. Senate,,O,"R. A. ""Skip"" Galan",2
 Acadia,01 01,U.S. Senate,,D,"""Chris"" John",323

--- a/2004/20041102__la__special__general.csv
+++ b/2004/20041102__la__special__general.csv
@@ -1,3 +1,3 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 St. Landry,State House,40,D,"Donald ""Don"" Cravins, Jr.",9019
 St. Landry,State House,40,D,"Alvin ""Chubby"" Haynes",8003

--- a/2004/20041102__la__special__general__precinct.csv
+++ b/2004/20041102__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 St. Landry,01 01,State House,40,D,"Donald ""Don"" Cravins, Jr.",158
 St. Landry,01 01,State House,40,D,"Alvin ""Chubby"" Haynes",145
 St. Landry,01 02,State House,40,D,"Donald ""Don"" Cravins, Jr.",404

--- a/2004/20041204__la__general.csv
+++ b/2004/20041204__la__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,U.S. Senate,,R,"""Bill"" Cassidy",13290
 Acadia,U.S. Senate,,D,Mary L. Landrieu,4751
 Allen,U.S. Senate,,R,"""Bill"" Cassidy",3646

--- a/2004/20041204__la__general__precinct.csv
+++ b/2004/20041204__la__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Acadia,01 01,U.S. House,7,R,"Charles Boustany, Jr.",215
 Acadia,01 01,U.S. House,7,D,Willie Landry Mount,80
 Acadia,01 02A,U.S. House,7,R,"Charles Boustany, Jr.",76

--- a/2004/20041204__la__special__primary.csv
+++ b/2004/20041204__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Orleans,State Senate,4,O,Clayton J. Joffrion,623
 Orleans,State Senate,4,D,"Edwin R. ""Ed"" Murray",6177
 Orleans,State Senate,4,O,Adam D. Wilson,384

--- a/2004/20041204__la__special__primary__precinct.csv
+++ b/2004/20041204__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Orleans,03 05,State Senate,4,O,Clayton J. Joffrion,4
 Orleans,03 05,State Senate,4,D,"Edwin R. ""Ed"" Murray",30
 Orleans,03 05,State Senate,4,O,Adam D. Wilson,0

--- a/2005/20050129__la__special__primary.csv
+++ b/2005/20050129__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Orleans,State House,96,D,Ray A. Bright,108
 Orleans,State House,96,D,Christopher Daigle,726
 Orleans,State House,96,D,Deborah Guy-Davenport,417

--- a/2005/20050129__la__special__primary__precinct.csv
+++ b/2005/20050129__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Orleans,06 01,State House,96,D,Ray A. Bright,2
 Orleans,06 01,State House,96,D,Christopher Daigle,73
 Orleans,06 01,State House,96,D,Deborah Guy-Davenport,3

--- a/2005/20050226__la__special__general.csv
+++ b/2005/20050226__la__special__general.csv
@@ -1,3 +1,3 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Orleans,State House,96,D,Juan LaFonta,1769
 Orleans,State House,96,D,Michael McKenna,1322

--- a/2005/20050226__la__special__general__precinct.csv
+++ b/2005/20050226__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Orleans,06 01,State House,96,D,Juan LaFonta,54
 Orleans,06 01,State House,96,D,Michael McKenna,29
 Orleans,06 02,State House,96,D,Juan LaFonta,71

--- a/2005/20050305__la__special__primary.csv
+++ b/2005/20050305__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 East Baton Rouge,State House,29,D,Raymond Allmon,189
 East Baton Rouge,State House,29,D,Regina Ashford Barrow,576
 East Baton Rouge,State House,29,D,Donald R. Dobbins,159

--- a/2005/20050305__la__special__primary__precinct.csv
+++ b/2005/20050305__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 East Baton Rouge,01 017,State House,29,D,Raymond Allmon,7
 East Baton Rouge,01 017,State House,29,D,Regina Ashford Barrow,7
 East Baton Rouge,01 017,State House,29,D,Donald R. Dobbins,1

--- a/2005/20050402__la__special__general.csv
+++ b/2005/20050402__la__special__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 East Baton Rouge,State House,29,D,Regina Ashford Barrow,1316
 East Baton Rouge,State House,29,D,Charles R. Kelly,983
 West Baton Rouge,State House,29,D,Regina Ashford Barrow,169

--- a/2005/20050402__la__special__general__precinct.csv
+++ b/2005/20050402__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 East Baton Rouge,01 017,State House,29,D,Regina Ashford Barrow,18
 East Baton Rouge,01 017,State House,29,D,Charles R. Kelly,5
 East Baton Rouge,01 023,State House,29,D,Regina Ashford Barrow,21

--- a/2005/20050521__la__special__primary.csv
+++ b/2005/20050521__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Jefferson,State Senate,3,O,Faris S. Altikriti,34
 Jefferson,State Senate,3,D,Wayne Baquet,133
 Jefferson,State Senate,3,D,Sandra Cabrina Jenkins,42

--- a/2005/20050521__la__special__primary__precinct.csv
+++ b/2005/20050521__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Jefferson,00 171,State Senate,3,O,Faris S. Altikriti,1
 Jefferson,00 171,State Senate,3,D,Wayne Baquet,0
 Jefferson,00 171,State Senate,3,D,Sandra Cabrina Jenkins,0

--- a/2005/20050604__la__special__primary.csv
+++ b/2005/20050604__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Jefferson,State Senate,6,D,Una Anderson,691
 Jefferson,State Senate,6,R,Jack M. Capella,897
 Jefferson,State Senate,6,R,John LaBruzzo,1084

--- a/2005/20050604__la__special__primary__precinct.csv
+++ b/2005/20050604__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Jefferson,00 030,State Senate,6,D,Una Anderson,42
 Jefferson,00 030,State Senate,6,R,Jack M. Capella,57
 Jefferson,00 030,State Senate,6,R,John LaBruzzo,69

--- a/2005/20050709__la__special__general.csv
+++ b/2005/20050709__la__special__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Jefferson,State Senate,6,R,Julie Quinn,3839
 Jefferson,State Senate,6,R,Diane Winston,1687
 Orleans,State Senate,6,R,Julie Quinn,1837

--- a/2005/20050709__la__special__general__precinct.csv
+++ b/2005/20050709__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Jefferson,00 030,State Senate,6,R,Julie Quinn,199
 Jefferson,00 030,State Senate,6,R,Diane Winston,104
 Jefferson,00 034,State Senate,6,R,Julie Quinn,153

--- a/2005/20050709__la__special__primary.csv
+++ b/2005/20050709__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Jefferson,State House,87,D,Terrell Harris,1804
 Jefferson,State House,87,D,Donald R. Jones,786
 Jefferson,State House,87,D,Dianne LePree-Williams,95

--- a/2005/20050709__la__special__primary__precinct.csv
+++ b/2005/20050709__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Jefferson,00 171,State House,87,D,Terrell Harris,7
 Jefferson,00 171,State House,87,D,Donald R. Jones,5
 Jefferson,00 171,State House,87,D,Dianne LePree-Williams,0

--- a/2006/20060401__la__special__primary.csv
+++ b/2006/20060401__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Grant,State House,22,D,Billy Chandler,961
 Grant,State House,22,D,Klark Hataway,1030
 Grant,State House,22,R,Lew Lasyone,202

--- a/2006/20060401__la__special__primary__precinct.csv
+++ b/2006/20060401__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Grant,01 1,State House,22,D,Billy Chandler,28
 Grant,01 1,State House,22,D,Klark Hataway,18
 Grant,01 1,State House,22,R,Lew Lasyone,1

--- a/2006/20060429__la__special__general.csv
+++ b/2006/20060429__la__special__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Grant,State House,22,D,Billy Chandler,2495
 Grant,State House,22,R,Tony K. Owens,806
 Lasalle,State House,22,D,Billy Chandler,1230

--- a/2006/20060429__la__special__general__precinct.csv
+++ b/2006/20060429__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Grant,01 1,State House,22,D,Billy Chandler,103
 Grant,01 1,State House,22,R,Tony K. Owens,24
 Grant,01 2,State House,22,D,Billy Chandler,69

--- a/2006/20060930__la__special__primary.csv
+++ b/2006/20060930__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,Secretary of State,,R,Mary Chehardy,617
 Acadia,Secretary of State,,L,Rayburn Clipper,142
 Acadia,Secretary of State,,N,"James ""Jim"" Crowley III",529

--- a/2006/20060930__la__special__primary__precinct.csv
+++ b/2006/20060930__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Acadia,01 01,Secretary of State,,R,Mary Chehardy,5
 Acadia,01 01,Secretary of State,,L,Rayburn Clipper,1
 Acadia,01 01,Secretary of State,,N,"James ""Jim"" Crowley III",3

--- a/2006/20061107__la__primary.csv
+++ b/2006/20061107__la__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Jefferson,U.S. House,1,L,Peter Beary,614
 Jefferson,U.S. House,1,D,David Gereighty,3549
 Jefferson,U.S. House,1,R,"""Bobby"" Jindal",52796

--- a/2006/20061107__la__primary__precinct.csv
+++ b/2006/20061107__la__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Ascension,00 01,U.S. House,6,R,Richard H. Baker,479
 Ascension,00 01,U.S. House,6,L,Richard M. Fontanesi,61
 Ascension,00 02,U.S. House,6,R,Richard H. Baker,381

--- a/2006/20061107__la__special__general.csv
+++ b/2006/20061107__la__special__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Concordia,State House,21,D,"""Andy"" Anders",4649
 Concordia,State House,21,D,Samuel Thomas,1263
 East Carroll,State House,21,D,"""Andy"" Anders",293

--- a/2006/20061107__la__special__general__precinct.csv
+++ b/2006/20061107__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Concordia,00 1-1,State House,21,D,"""Andy"" Anders",136
 Concordia,00 1-1,State House,21,D,Samuel Thomas,237
 Concordia,00 1-2,State House,21,D,"""Andy"" Anders",63

--- a/2006/20061209__la__general.csv
+++ b/2006/20061209__la__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Jefferson,U.S. House,2,D,Karen Carter,4967
 Jefferson,U.S. House,2,D,William J. Jefferson,11935
 Orleans,U.S. House,2,D,Karen Carter,22044

--- a/2006/20061209__la__general__precinct.csv
+++ b/2006/20061209__la__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Jefferson,00 057,U.S. House,2nd Congressional District,D,Karen Carter,53
 Jefferson,00 057,U.S. House,2nd Congressional District,D,William J. Jefferson,45
 Jefferson,00 104,U.S. House,2nd Congressional District,D,Karen Carter,49

--- a/2007/20070224__la__special__primary.csv
+++ b/2007/20070224__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Bossier,State House,1,R,Michael Page Boyter,3
 Bossier,State House,1,D,"Richard ""Richie"" Hollier",66
 Bossier,State House,1,D,Ruth W. Johnston,61

--- a/2007/20070224__la__special__primary__precinct.csv
+++ b/2007/20070224__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Caddo,00 001,State House,4,D,Larry Ferdinand,8
 Caddo,00 001,State House,4,D,Reginald Johnson,7
 Caddo,00 001,State House,4,D,"Calvin ""Ben"" Lester, Jr.",20

--- a/2007/20070310__la__special__primary.csv
+++ b/2007/20070310__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Orleans,State House,94,R,Philip C. Brickman,186
 Orleans,State House,94,R,"""Jeb"" Bruneau",1331
 Orleans,State House,94,D,"John M. Holahan, Jr.",667

--- a/2007/20070310__la__special__primary__precinct.csv
+++ b/2007/20070310__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Orleans,03 14,State House,94,R,Philip C. Brickman,1
 Orleans,03 14,State House,94,R,"""Jeb"" Bruneau",2
 Orleans,03 14,State House,94,D,"John M. Holahan, Jr.",1

--- a/2007/20070331__la__special__general.csv
+++ b/2007/20070331__la__special__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Caddo,State House,4,D,Larry Ferdinand,1214
 Caddo,State House,4,D,Patrick C. Williams,2321
 St. Landry,State House,40,D,Elbert Lee Guillory,3677

--- a/2007/20070331__la__special__general__precinct.csv
+++ b/2007/20070331__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Orleans,03 14,State House,94,R,"""Jeb"" Bruneau",5
 Orleans,03 14,State House,94,R,"Nicholas J. ""Nick"" Lorusso",17
 Orleans,03 19,State House,94,R,"""Jeb"" Bruneau",15

--- a/2007/20071020__la__primary.csv
+++ b/2007/20071020__la__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,Governor,,O,B. Alexandrenko,52
 Acadia,Governor,,D,Walter J. Boasso,4099
 Acadia,Governor,,D,Foster Campbell,1693

--- a/2007/20071117__la__general.csv
+++ b/2007/20071117__la__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,Attorney General,,R,Royal Alexander,3124
 Acadia,Attorney General,,D,"James D. ""Buddy"" Caldwell",5371
 Allen,Attorney General,,R,Royal Alexander,1874

--- a/2007/20071117__la__general__precinct.csv
+++ b/2007/20071117__la__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Acadia,01 01,Attorney General,,R,Royal Alexander,101
 Acadia,01 01,Attorney General,,D,"James D. ""Buddy"" Caldwell",186
 Acadia,01 02A,Attorney General,,R,Royal Alexander,19

--- a/2008/20080209__la__primary.csv
+++ b/2008/20080209__la__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,President,,D,"""Joe"" Biden",100
 Acadia,President,,D,Hillary Clinton,2030
 Acadia,President,,D,Christopher J. Dodd,32

--- a/2008/20080209__la__special__primary.csv
+++ b/2008/20080209__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Bossier,State House,6,R,Thomas Carmody,273
 Bossier,State House,6,R,Barrow Peacock,499
 Caddo,State House,6,R,Thomas Carmody,3754

--- a/2008/20080209__la__special__primary__precinct.csv
+++ b/2008/20080209__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Bossier,01 03A,State House,6,R,Thomas Carmody,69
 Bossier,01 03A,State House,6,R,Barrow Peacock,116
 Bossier,01 04A,State House,6,R,Thomas Carmody,10

--- a/2008/20080308__la__special__primary.csv
+++ b/2008/20080308__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Jefferson,U.S. House,1,D,"M. V. ""Vinny"" Mendoza",1796
 Jefferson,U.S. House,1,D,Gilda Reed,3747
 Orleans,U.S. House,1,D,"M. V. ""Vinny"" Mendoza",201

--- a/2008/20080308__la__special__primary__precinct.csv
+++ b/2008/20080308__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Jefferson,00 001,U.S. House,1 -,D,"M. V. ""Vinny"" Mendoza",12
 Jefferson,00 001,U.S. House,1 -,D,Gilda Reed,34
 Jefferson,00 002,U.S. House,1 -,D,"M. V. ""Vinny"" Mendoza",14

--- a/2008/20080405__la__special__primary_runoff.csv
+++ b/2008/20080405__la__special__primary_runoff.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Jefferson,U.S. House,1,R,"""Tim"" Burns",2242
 Jefferson,U.S. House,1,R,"""Steve"" Scalise",11270
 Orleans,U.S. House,1,R,"""Tim"" Burns",356

--- a/2008/20080405__la__special__primary_runoff__precinct.csv
+++ b/2008/20080405__la__special__primary_runoff__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Ascension,00 01,U.S. House,6 -,D,"""Don"" Cazayoux",30
 Ascension,00 01,U.S. House,6 -,D,Michael Jackson,23
 Ascension,00 02,U.S. House,6 -,D,"""Don"" Cazayoux",51

--- a/2008/20080503__la__special__general.csv
+++ b/2008/20080503__la__special__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Jefferson,U.S. House,1,N,"R. A. ""Skip"" Galan",387
 Jefferson,U.S. House,1,O,"Anthony ""Tony G"" Gentile",88
 Jefferson,U.S. House,1,D,Gilda Reed,3364

--- a/2008/20080503__la__special__general__precinct.csv
+++ b/2008/20080503__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Jefferson,00 001,U.S. House,1,N,"R. A. ""Skip"" Galan",0
 Jefferson,00 001,U.S. House,1,O,"Anthony ""Tony G"" Gentile",0
 Jefferson,00 001,U.S. House,1,D,Gilda Reed,34

--- a/2008/20081004__la__primary.csv
+++ b/2008/20081004__la__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Jefferson,U.S. House,1,D,"""Jim"" Harlan",10740
 Jefferson,U.S. House,1,D,"M.V. ""Vinny"" Mendoza",4882
 Orleans,U.S. House,1,D,"""Jim"" Harlan",3005

--- a/2008/20081004__la__primary__precinct.csv
+++ b/2008/20081004__la__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Allen,01 01,U.S. House,4 -,D,Willie Banks,35
 Allen,01 01,U.S. House,4 -,D,Paul J. Carmouche,45
 Allen,01 01,U.S. House,4 -,D,"Artis ""Doc"" Cash",13

--- a/2008/20081004__la__special__primary.csv
+++ b/2008/20081004__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Jefferson,State Senate,9,R,Conrad Appel,5770
 Jefferson,State Senate,9,R,"Allen ""Al"" Leone",3383
 Jefferson,State Senate,9,R,"""Polly"" Thomas",7715

--- a/2008/20081004__la__special__primary__precinct.csv
+++ b/2008/20081004__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Jefferson,00 002,State Senate,9,R,Conrad Appel,82
 Jefferson,00 002,State Senate,9,R,"Allen ""Al"" Leone",75
 Jefferson,00 002,State Senate,9,R,"""Polly"" Thomas",131

--- a/2008/20081104__la__general.csv
+++ b/2008/20081104__la__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,President,,D,"Barack Obama, Joe Biden",7028
 Acadia,President,,G,"Cynthia McKinney,Rosa Clemente",182
 Acadia,President,,R,"John McCain, Sarah Palin",19229

--- a/2008/20081104__la__general__precinct.csv
+++ b/2008/20081104__la__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Acadia,01 01,President,,D,"Barack Obama, Joe Biden",115
 Acadia,01 01,President,,G,"Cynthia McKinney,Rosa Clemente",9
 Acadia,01 01,President,,R,"John McCain, Sarah Palin",603

--- a/2008/20081104__la__special__general.csv
+++ b/2008/20081104__la__special__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Jefferson,State Senate,9,R,Conrad Appel,21853
 Jefferson,State Senate,9,R,"""Polly"" Thomas",20065
 Pointe Coupee,State House,18,D,Troy Grezaffi,6061

--- a/2008/20081104__la__special__general__precinct.csv
+++ b/2008/20081104__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Jefferson,00 002,State Senate,9,R,Conrad Appel,369
 Jefferson,00 002,State Senate,9,R,"""Polly"" Thomas",280
 Jefferson,00 003,State Senate,9,R,Conrad Appel,299

--- a/2008/20081206__la__general_runoff.csv
+++ b/2008/20081206__la__general_runoff.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Jefferson,U.S. House,2,R,"Anh ""Joseph"" Cao",12696
 Jefferson,U.S. House,2,D,William J. Jefferson,8099
 Jefferson,U.S. House,2,L,Gregory W. Kahn,175

--- a/2008/20081206__la__general_runoff__precinct.csv
+++ b/2008/20081206__la__general_runoff__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Jefferson,00 057,U.S. House,2nd Congressional District,R,"Anh ""Joseph"" Cao",151
 Jefferson,00 057,U.S. House,2nd Congressional District,D,William J. Jefferson,15
 Jefferson,00 057,U.S. House,2nd Congressional District,L,Gregory W. Kahn,0

--- a/2008/20081206__la__special__primary.csv
+++ b/2008/20081206__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Jefferson,State Senate,3,D,Shawn Barney,1592
 Jefferson,State Senate,3,D,"""J.P."" Morrell",1647
 Orleans,State Senate,3,D,Shawn Barney,2966

--- a/2008/20081206__la__special__primary__precinct.csv
+++ b/2008/20081206__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Jefferson,00 171,State Senate,3,D,Shawn Barney,9
 Jefferson,00 171,State Senate,3,D,"""J.P."" Morrell",5
 Jefferson,00 172,State Senate,3,D,Shawn Barney,105

--- a/2009/20090307__la__special__primary.csv
+++ b/2009/20090307__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 East Baton Rouge,State Senate,16,R,Laurinda L. Calongne,4511
 East Baton Rouge,State Senate,16,R,"""Dan"" Claitor",6509
 East Baton Rouge,State Senate,16,R,Lee Domingue,5760

--- a/2009/20090307__la__special__primary__precinct.csv
+++ b/2009/20090307__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 East Baton Rouge,01 009,State Senate,16,R,Laurinda L. Calongne,46
 East Baton Rouge,01 009,State Senate,16,R,"""Dan"" Claitor",66
 East Baton Rouge,01 009,State Senate,16,R,Lee Domingue,73

--- a/2009/20090404__la__special__general.csv
+++ b/2009/20090404__la__special__general.csv
@@ -1,3 +1,3 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 East Baton Rouge,State Senate,16,R,"""Dan"" Claitor",11713
 East Baton Rouge,State Senate,16,R,Lee Domingue,6114

--- a/2009/20090404__la__special__general__precinct.csv
+++ b/2009/20090404__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 East Baton Rouge,01 009,State Senate,16,R,"""Dan"" Claitor",110
 East Baton Rouge,01 009,State Senate,16,R,Lee Domingue,102
 East Baton Rouge,01 012A,State Senate,16,R,"""Dan"" Claitor",134

--- a/2009/20090404__la__special__primary.csv
+++ b/2009/20090404__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Lafayette,State Senate,24,D,"Patricia ""Pat"" Cravins",1805
 Lafayette,State Senate,24,D,Elbert L. Guillory,810
 Lafayette,State Senate,24,D,"Quincy Richard, Jr.",114

--- a/2009/20090404__la__special__primary__precinct.csv
+++ b/2009/20090404__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Orleans,07 25,State House,97,D,Jared Brossett,45
 Orleans,07 25,State House,97,R,"Oliver ""Bishop OC"" Coleman",6
 Orleans,07 25,State House,97,D,Leroy Doucette,30

--- a/2009/20090502__la__special__general.csv
+++ b/2009/20090502__la__special__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Lafayette,State Senate,24,D,"Patricia ""Pat"" Cravins",1837
 Lafayette,State Senate,24,D,Elbert L. Guillory,1175
 St. Landry,State Senate,24,D,"Patricia ""Pat"" Cravins",2909

--- a/2009/20090502__la__special__general__precinct.csv
+++ b/2009/20090502__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Orleans,07 25,State House,97,D,Jared Brossett,42
 Orleans,07 25,State House,97,D,Leroy Doucette,42
 Orleans,07 25A,State House,97,D,Jared Brossett,42

--- a/2009/20090801__la__special__primary.csv
+++ b/2009/20090801__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Lafourche,State Senate,20,D,Damon J. Baldone,1359
 Lafourche,State Senate,20,R,Brent Callais,2245
 Lafourche,State Senate,20,D,"""Norby"" Chabert",1954

--- a/2009/20090801__la__special__primary__precinct.csv
+++ b/2009/20090801__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Lafourche,03 04,State Senate,20,D,Damon J. Baldone,17
 Lafourche,03 04,State Senate,20,R,Brent Callais,38
 Lafourche,03 04,State Senate,20,D,"""Norby"" Chabert",22

--- a/2009/20090829__la__special__general.csv
+++ b/2009/20090829__la__special__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Lafourche,State Senate,20,R,Brent Callais,3342
 Lafourche,State Senate,20,D,"""Norby"" Chabert",4085
 Terrebonne,State Senate,20,R,Brent Callais,4708

--- a/2009/20090829__la__special__general__precinct.csv
+++ b/2009/20090829__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Lafourche,03 04,State Senate,20,R,Brent Callais,66
 Lafourche,03 04,State Senate,20,D,"""Norby"" Chabert",41
 Lafourche,03 05,State Senate,20,R,Brent Callais,120

--- a/2010/20100206__la__special__primary.csv
+++ b/2010/20100206__la__special__primary.csv
@@ -1,3 +1,3 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Orleans,State Senate,5,D,Karen Carter Peterson,13509
 Orleans,State Senate,5,D,Irma Muse Dixon,3734

--- a/2010/20100206__la__special__primary__precinct.csv
+++ b/2010/20100206__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Orleans,01 01,State Senate,5,D,Karen Carter Peterson,98
 Orleans,01 01,State Senate,5,D,Irma Muse Dixon,23
 Orleans,01 02,State Senate,5,D,Karen Carter Peterson,90

--- a/2010/20100501__la__special__primary.csv
+++ b/2010/20100501__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 East Baton Rouge,State House,63,D,"Ulysses ""Bones"" Addison",1293
 East Baton Rouge,State House,63,D,Dalton Honore,1706
 East Baton Rouge,State House,63,N,"Dadrius ""D20"" Lanus",144

--- a/2010/20100501__la__special__primary__precinct.csv
+++ b/2010/20100501__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Orleans,01 01,State House,93,D,Louis Charbonnet III,3
 Orleans,01 01,State House,93,D,Rhodesia Jackson Douglas,0
 Orleans,01 01,State House,93,D,Carlos J. Hornbrook,1

--- a/2010/20100529__la__special__general.csv
+++ b/2010/20100529__la__special__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 East Baton Rouge,State House,63,D,"Ulysses ""Bones"" Addison",816
 East Baton Rouge,State House,63,D,Dalton Honore,1631
 Orleans,State House,93,D,Helena Moreno,1274

--- a/2010/20100529__la__special__general__precinct.csv
+++ b/2010/20100529__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Orleans,01 01,State House,93,D,Helena Moreno,16
 Orleans,01 01,State House,93,D,James Perry,11
 Orleans,01 02,State House,93,D,Helena Moreno,23

--- a/2010/20100828__la__primary.csv
+++ b/2010/20100828__la__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,U.S. Senate,Democratic Party,D,"Neeson J. Chauvin, Jr.",382
 Acadia,U.S. Senate,Democratic Party,D,Cary J. Deaton,274
 Acadia,U.S. Senate,Democratic Party,D,"""Charlie"" Melancon",927

--- a/2010/20100828__la__primary__precinct.csv
+++ b/2010/20100828__la__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Acadia,01 01,U.S. Senate,Democratic Party,D,"Neeson J. Chauvin, Jr.",13
 Acadia,01 01,U.S. Senate,Democratic Party,D,Cary J. Deaton,7
 Acadia,01 01,U.S. Senate,Democratic Party,D,"""Charlie"" Melancon",15

--- a/2010/20101002__la__primary_runoff.csv
+++ b/2010/20101002__la__primary_runoff.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Ascension,U.S. House,3,R,"""Hunt"" Downer",419
 Ascension,U.S. House,3,R,"""Jeff"" Landry",1244
 Assumption,U.S. House,3,R,"""Hunt"" Downer",209

--- a/2010/20101002__la__primary_runoff__precinct.csv
+++ b/2010/20101002__la__primary_runoff__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Ascension,00 22,U.S. House,3rd Congressional District-Republican Party,R,"""Hunt"" Downer",12
 Ascension,00 22,U.S. House,3rd Congressional District-Republican Party,R,"""Jeff"" Landry",44
 Ascension,00 23,U.S. House,3rd Congressional District-Republican Party,R,"""Hunt"" Downer",3

--- a/2010/20101002__la__special__primary.csv
+++ b/2010/20101002__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,Lieutenant Governor,,D,"James ""Jim"" Crowley",845
 Acadia,Lieutenant Governor,,R,"""Jay"" Dardenne",2178
 Acadia,Lieutenant Governor,,R,Kevin Davis,368

--- a/2010/20101002__la__special__primary__precinct.csv
+++ b/2010/20101002__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Acadia,01 01,Lieutenant Governor,,D,"James ""Jim"" Crowley",13
 Acadia,01 01,Lieutenant Governor,,R,"""Jay"" Dardenne",40
 Acadia,01 01,Lieutenant Governor,,R,Kevin Davis,10

--- a/2010/20101102__la__primary.csv
+++ b/2010/20101102__la__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,U.S. Senate,,N,Michael Karlton Brown,146
 Acadia,U.S. Senate,,N,"R. A. ""Skip"" Galan",80
 Acadia,U.S. Senate,,N,Milton Gordon,87

--- a/2010/20101102__la__primary__precinct.csv
+++ b/2010/20101102__la__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Acadia,01 01,U.S. Senate,,N,Michael Karlton Brown,5
 Acadia,01 01,U.S. Senate,,N,"R. A. ""Skip"" Galan",4
 Acadia,01 01,U.S. Senate,,N,Milton Gordon,3

--- a/2010/20101102__la__special__general.csv
+++ b/2010/20101102__la__special__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,Lieutenant Governor,,R,"""Jay"" Dardenne",10745
 Acadia,Lieutenant Governor,,D,Caroline Fayard,6437
 Allen,Lieutenant Governor,,R,"""Jay"" Dardenne",2993

--- a/2010/20101102__la__special__general__precinct.csv
+++ b/2010/20101102__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Acadia,01 01,Lieutenant Governor,,R,"""Jay"" Dardenne",321
 Acadia,01 01,Lieutenant Governor,,D,Caroline Fayard,153
 Acadia,01 02A,Lieutenant Governor,,R,"""Jay"" Dardenne",181

--- a/2011/20110122__la__special__primary.csv
+++ b/2011/20110122__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Iberia,State Senate,22,R,Simone B. Champagne,3623
 Iberia,State Senate,22,N,David Groner,2008
 Iberia,State Senate,22,N,Ruben LeBlanc,126

--- a/2011/20110122__la__special__primary__precinct.csv
+++ b/2011/20110122__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Orleans,09 32,State House,101,D,Roland Barthe,1
 Orleans,09 32,State House,101,D,Wesley T. Bishop,16
 Orleans,09 32,State House,101,D,Willie Jones,2

--- a/2011/20110219__la__special__primary.csv
+++ b/2011/20110219__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,State Senate,26,D,Nathan Granger,2095
 Acadia,State Senate,26,R,Jonathan Perry,2080
 Lafayette,State Senate,26,D,Nathan Granger,1000

--- a/2011/20110219__la__special__primary__precinct.csv
+++ b/2011/20110219__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Acadia,01 01,State Senate,26,D,Nathan Granger,94
 Acadia,01 01,State Senate,26,R,Jonathan Perry,111
 Acadia,01 02A,State Senate,26,D,Nathan Granger,55

--- a/2011/20110402__la__special__primary.csv
+++ b/2011/20110402__la__special__primary.csv
@@ -1,3 +1,3 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 St. Martin,State House,46,R,"""Mike Pete"" Huval",4338
 St. Martin,State House,46,R,Craig Prosper,3144

--- a/2011/20110402__la__special__primary__precinct.csv
+++ b/2011/20110402__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 St. Martin,01 1,State House,46,R,"""Mike Pete"" Huval",47
 St. Martin,01 1,State House,46,R,Craig Prosper,63
 St. Martin,01 3,State House,46,R,"""Mike Pete"" Huval",12

--- a/2011/20110430__la__special__primary.csv
+++ b/2011/20110430__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Cameron,State House,47,R,Linda Hardee,302
 Cameron,State House,47,R,"""Bob"" Hensgens",663
 Vermilion,State House,47,R,Linda Hardee,2863

--- a/2011/20110430__la__special__primary__precinct.csv
+++ b/2011/20110430__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Cameron,00 01,State House,47,R,Linda Hardee,14
 Cameron,00 01,State House,47,R,"""Bob"" Hensgens",18
 Cameron,00 02,State House,47,R,Linda Hardee,0

--- a/2011/20111022__la__primary.csv
+++ b/2011/20111022__la__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,Governor,,N,David Blanchard,375
 Acadia,Governor,,N,"Leonard ""Lenny"" Bollingham",63
 Acadia,Governor,,N,"""Ron"" Ceasar",93

--- a/2011/20111119__la__general.csv
+++ b/2011/20111119__la__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Ascension,State Senate,2,D,Elton M. Aubert,1593
 Ascension,State Senate,2,D,Troy E. Brown,1738
 Assumption,State Senate,2,D,Elton M. Aubert,761

--- a/2011/20111119__la__general__precinct.csv
+++ b/2011/20111119__la__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 East Baton Rouge,02 021 A,State House,62,D,"""Ken"" Dawson",68
 East Baton Rouge,02 021 A,State House,62,R,"""Kenny"" Havard",173
 East Baton Rouge,02 021 B,State House,62,D,"""Ken"" Dawson",55

--- a/2012/20120324__la__primary.csv
+++ b/2012/20120324__la__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,President,,D,"""Bob"" Ely",131
 Acadia,President,,D,Barack Obama,693
 Acadia,President,,D,Darcy G. Richardson,116

--- a/2012/20120324__la__primary__precinct.csv
+++ b/2012/20120324__la__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Acadia,01 01,President,Democratic Party,D,"""Bob"" Ely",5
 Acadia,01 01,President,Democratic Party,D,Barack Obama,3
 Acadia,01 01,President,Democratic Party,D,Darcy G. Richardson,1

--- a/2012/20121106__la__general.csv
+++ b/2012/20121106__la__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,President,,D,"Barack Obama, Joe Biden",6560
 Acadia,President,,G,"Jill Stein, Cheri Honkala",101
 Acadia,President,,L,"Gary Johnson, James P. Gray",144

--- a/2012/20121106__la__general__precinct.csv
+++ b/2012/20121106__la__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Acadia,01 01,President,,D,"Barack Obama, Joe Biden Democratic",82
 Acadia,01 01,President,,G,"Jill Stein, Cheri Honkala Green",1
 Acadia,01 01,President,,L,"Gary Johnson, James P. Gray Libertarian",12

--- a/2012/20121106__la__primary.csv
+++ b/2012/20121106__la__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Jefferson,U.S. House,1,R,Gary King,5506
 Jefferson,U.S. House,1,D,"M. V. ""Vinny"" Mendoza",16417
 Jefferson,U.S. House,1,R,"""Steve"" Scalise",64069

--- a/2012/20121106__la__primary__precinct.csv
+++ b/2012/20121106__la__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Ascension,00 01 A,U.S. House,6,R,"William ""Bill"" Cassidy",594
 Ascension,00 01 A,U.S. House,6,L,"Rufus Holt Craig, Jr.",54
 Ascension,00 01 A,U.S. House,6,N,"Richard ""RPT"" Torregano",43

--- a/2012/20121208__la__general.csv
+++ b/2012/20121208__la__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,U.S. House,3,R,"Charles W. Boustany, Jr.",7275
 Acadia,U.S. House,3,R,"""Jeff"" Landry",2801
 Calcasieu,U.S. House,3,R,"Charles W. Boustany, Jr.",13301

--- a/2012/20121208__la__general__precinct.csv
+++ b/2012/20121208__la__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Acadia,01 01,U.S. House,3rd Congressional District,R,"Charles W. Boustany, Jr.",149
 Acadia,01 01,U.S. House,3rd Congressional District,R,"""Jeff"" Landry",115
 Acadia,01 02A,U.S. House,3rd Congressional District,R,"Charles W. Boustany, Jr.",134

--- a/2013/20130302__la__special__primary.csv
+++ b/2013/20130302__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 East Baton Rouge,State House,65,R,Barry Ivey,2202
 East Baton Rouge,State House,65,R,Scott Wilson,1953
 Jefferson,State House,79,R,Allison Bent Bowler,447

--- a/2013/20130302__la__special__primary__precinct.csv
+++ b/2013/20130302__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 East Baton Rouge,01 089,State House,65,R,Barry Ivey,62
 East Baton Rouge,01 089,State House,65,R,Scott Wilson,41
 East Baton Rouge,01 097,State House,65,R,Barry Ivey,19

--- a/2013/20131019__la__special__primary.csv
+++ b/2013/20131019__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Avoyelles,U.S. House,5,G,Eliot S. Barron,16
 Avoyelles,U.S. House,5,O,"""Tom"" Gibbs",9
 Avoyelles,U.S. House,5,L,"Henry Herford, Jr.",19

--- a/2013/20131019__la__special__primary__precinct.csv
+++ b/2013/20131019__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Avoyelles,01 01,U.S. House,5,G,Eliot S. Barron,0
 Avoyelles,01 01,U.S. House,5,O,"""Tom"" Gibbs",0
 Avoyelles,01 01,U.S. House,5,L,"Henry Herford, Jr.",1

--- a/2013/20131116__la__special__general.csv
+++ b/2013/20131116__la__special__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Avoyelles,U.S. House,5,R,Vance M. McAllister,1657
 Avoyelles,U.S. House,5,R,Neil Riser,1514
 Caldwell,U.S. House,5,R,Vance M. McAllister,567

--- a/2013/20131116__la__special__general__precinct.csv
+++ b/2013/20131116__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Avoyelles,01 01,U.S. House,5,R,Vance M. McAllister,67
 Avoyelles,01 01,U.S. House,5,R,Neil Riser,56
 Avoyelles,01 02,U.S. House,5,R,Vance M. McAllister,66

--- a/2014/20141104__la__primary.csv
+++ b/2014/20141104__la__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,U.S. Senate,,D,Wayne Ables,217
 Acadia,U.S. Senate,,R,"""Bill"" Cassidy",10196
 Acadia,U.S. Senate,,R,Thomas Clements,214

--- a/2014/20141104__la__primary__precinct.csv
+++ b/2014/20141104__la__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Acadia,01 01,U.S. Senate,,D,Wayne Ables,5
 Acadia,01 01,U.S. Senate,,R,"""Bill"" Cassidy",299
 Acadia,01 01,U.S. Senate,,R,Thomas Clements,5

--- a/2014/20141206__la__general.csv
+++ b/2014/20141206__la__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,U.S. Senate,,R,"""Bill"" Cassidy",13290
 Acadia,U.S. Senate,,D,Mary L. Landrieu,4751
 Allen,U.S. Senate,,R,"""Bill"" Cassidy",3646

--- a/2014/20141206__la__general__precinct.csv
+++ b/2014/20141206__la__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Acadia,01 01,U.S. Senate,,R,"""Bill"" Cassidy",407
 Acadia,01 01,U.S. Senate,,D,Mary L. Landrieu,81
 Acadia,01 02A,U.S. Senate,,R,"""Bill"" Cassidy",125

--- a/2015/20150221__la__special__primary.csv
+++ b/2015/20150221__la__special__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Rapides,State House,26,D,"""Jeff"" Hall",3361
 Rapides,State House,26,D,"Alice ""Red"" Hammond",180
 Rapides,State House,26,D,Daniel Williams,457

--- a/2015/20150221__la__special__primary__precinct.csv
+++ b/2015/20150221__la__special__primary__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 East Baton Rouge,01 090 A,State House,66,R,"""Buddy"" Amoroso",22
 East Baton Rouge,01 090 A,State House,66,R,"Richard ""Rick"" Bond",26
 East Baton Rouge,01 090 A,State House,66,N,Susan Nelson,24

--- a/2015/20150328__la__special__general.csv
+++ b/2015/20150328__la__special__general.csv
@@ -1,3 +1,3 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 East Baton Rouge,State House,66,R,"""Buddy"" Amoroso",1886
 East Baton Rouge,State House,66,R,Darrell Ourso,1958

--- a/2015/20150328__la__special__general__precinct.csv
+++ b/2015/20150328__la__special__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 East Baton Rouge,01 090 A,State House,66,R,"""Buddy"" Amoroso",37
 East Baton Rouge,01 090 A,State House,66,R,Darrell Ourso,63
 East Baton Rouge,01 090 B,State House,66,R,"""Buddy"" Amoroso",40

--- a/2015/20151024__la__primary.csv
+++ b/2015/20151024__la__primary.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,Governor,,R,Scott A. Angelle,5884
 Acadia,Governor,,N,Beryl Billiot,67
 Acadia,Governor,,R,"""Jay"" Dardenne",2176

--- a/2015/20151121__la__general.csv
+++ b/2015/20151121__la__general.csv
@@ -1,4 +1,4 @@
-parish,office,district,party,candidate,votes
+county,office,district,party,candidate,votes
 Acadia,Governor,,D,John Bel Edwards,6395
 Acadia,Governor,,R,David Vitter,8595
 Allen,Governor,,D,John Bel Edwards,2915

--- a/2015/20151121__la__general__precinct.csv
+++ b/2015/20151121__la__general__precinct.csv
@@ -1,4 +1,4 @@
-parish,precinct,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Acadia,01 01,Lieutenant Governor,,D,"Melvin L. ""Kip"" Holden",74
 Acadia,01 01,Lieutenant Governor,,R,"""Billy"" Nungesser",374
 Acadia,01 02A,Lieutenant Governor,,D,"Melvin L. ""Kip"" Holden",61


### PR DESCRIPTION
Louisiana has parishes instead of counties.  However, to be consistent with the data files from other states, we will use `county` as the column header.

This fixes #7.